### PR TITLE
EMP-104: Add length setter and HTML escaping functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Control Center Monorepo
 
--   Applications
-    -   Admin Dashboard
--   Angular Libraries
-    -   MatEz (eazy-to-use library that extends Angular Material)
-    -   Configs (for Prettier, ESLint, CSpell)
+- Applications
+    - Admin Dashboard
+- Angular Libraries
+    - MatEz (eazy-to-use library that extends Angular Material)
+    - Configs (for Prettier, ESLint, CSpell)
 
 ## Control Center App
 
@@ -26,8 +26,8 @@ You can copy from examples like this one: [`_appConfig.json`](./apps/control-cen
 
 Running in stage mode needs files:
 
--   `apps/control-center/src/assets/appConfig.stage.json`
--   `apps/control-center/src/assets/authConfig.stage.json`
+- `apps/control-center/src/assets/appConfig.stage.json`
+- `apps/control-center/src/assets/authConfig.stage.json`
 
 ### 🚀 Launch
 
@@ -48,5 +48,5 @@ npm run dev-libs
 
 #### Console Utilities
 
--   `ccSwitchLogging()` - Enable/disable logging requests to the console
--   `ccGetMyRoles()` - Display your roles from the token
+- `ccSwitchLogging()` - Enable/disable logging requests to the console
+- `ccGetMyRoles()` - Display your roles from the token

--- a/libs/matez/src/lib/components/table/utils/table-data-source.ts
+++ b/libs/matez/src/lib/components/table/utils/table-data-source.ts
@@ -72,7 +72,7 @@ class OnePageTableDataSourcePaginator implements Partial<MatPaginator> {
         return this.pageSize;
     }
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    set length(_length) {} 
+    set length(_length) {}
 
     get displayedPages() {
         return this.pageSize / this.partSize;

--- a/libs/matez/src/lib/components/table/utils/table-data-source.ts
+++ b/libs/matez/src/lib/components/table/utils/table-data-source.ts
@@ -71,6 +71,8 @@ class OnePageTableDataSourcePaginator implements Partial<MatPaginator> {
     get length() {
         return this.pageSize;
     }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    set length(_length) {} 
 
     get displayedPages() {
         return this.pageSize / this.partSize;

--- a/libs/matez/src/lib/directives/highlight.directive.ts
+++ b/libs/matez/src/lib/directives/highlight.directive.ts
@@ -1,11 +1,11 @@
 import {
     Directive,
-    Renderer2,
     ElementRef,
     OnInit,
     input,
-    DestroyRef,
     Injector,
+    DestroyRef,
+    Renderer2,
 } from '@angular/core';
 import { toObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { combineLatest } from 'rxjs';
@@ -32,9 +32,11 @@ export class HighlightDirective implements OnInit {
         combineLatest([
             toObservable(this.vHighlightText, { injector: this.injector }).pipe(
                 distinctUntilChanged(),
+                map((text) => this.escapeHtml(text)),
             ),
             toObservable(this.vHighlightSearch, { injector: this.injector }).pipe(
                 distinctUntilChanged(),
+                map((text) => this.escapeHtml(text)),
             ),
         ])
             .pipe(
@@ -51,5 +53,14 @@ export class HighlightDirective implements OnInit {
             .subscribe((text) => {
                 this.renderer.setProperty(this.el.nativeElement, 'innerHTML', text);
             });
+    }
+
+    private escapeHtml(html: string): string {
+        return html
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
     }
 }


### PR DESCRIPTION
Introduce a setter for the length property in the paginator and implement a method to escape HTML in the highlight directive to enhance security and functionality.